### PR TITLE
GPU Acceleration for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Use the included `buildozer.spec` file or make the following changes to one crea
 ```
 source.include_exts = py,png,jpg,kv,atlas,tflite
 requirements = python3,kivy,numpy
-android.api = 30
+android.api = 35
 android.minapi = 24
-android.gradle_dependencies = org.tensorflow:tensorflow-lite:+,org.tensorflow:tensorflow-lite-support:+
+android.gradle_dependencies = com.google.ai.edge.litert:litert:1.4.1, com.google.ai.edge.litert:litert-support:1.4.1, com.google.ai.edge.litert:litert-gpu:1.4.1, com.google.ai.edge.litert:litert-gpu-api:1.4.1
 ```
+
+You only need ```com.google.ai.edge.litert:litert-gpu:1.4.1, com.google.ai.edge.litert:litert-gpu-api:1.4.1``` if you want to use gpu acceleration.
 
 Note that if your `tflite` model file is too big to be packaged with your APK, you will have to find some other way of getting it on to the device. If this is the case then change this line to ensure it is not included in the package.
 
@@ -60,6 +62,10 @@ and install it with
 ```bash
 adb install bin/myapp-0.1-x86-debug.apk
 ```
+
+### java.lang.ClassNotFoundException
+
+This is a known problem of pyjnius if you try to access java classes from a non-main thread. If you encounter this problem, you should try to create the TensorFlowModel class from the main thread and than run  ```load()``` and ```pred()``` from a seperate thread. If this doesn't work please use try using the main thread for everything.
 
 ## iOS
 

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -99,7 +99,7 @@ fullscreen = 0
 #android.features = android.hardware.usb.host
 
 # (int) Target Android API, should be as high as possible.
-android.api = 30
+android.api = 35
 
 # (int) Minimum API your APK / AAB will support.
 android.minapi = 24
@@ -187,7 +187,8 @@ android.minapi = 24
 #android.add_assets =
 
 # (list) Gradle dependencies to add
-android.gradle_dependencies = org.tensorflow:tensorflow-lite:+,org.tensorflow:tensorflow-lite-support:+
+# The last two are only needed if you want to use gpu acceleration
+android.gradle_dependencies = com.google.ai.edge.litert:litert:1.4.1, com.google.ai.edge.litert:litert-support:1.4.1, com.google.ai.edge.litert:litert-gpu:1.4.1, com.google.ai.edge.litert:litert-gpu-api:1.4.1
 
 # (bool) Enable AndroidX support. Enable when 'android.gradle_dependencies'
 # contains an 'androidx' package, or any package from Kotlin source.

--- a/main.py
+++ b/main.py
@@ -9,8 +9,8 @@ from model import TensorFlowModel
 class MyApp(App):
 
     def build(self):
-        model = TensorFlowModel()
-        model.load(os.path.join(os.getcwd(), 'model.tflite'))
+        model = TensorFlowModel(os.path.join(os.getcwd(), 'model.tflite'))
+        model.load()
         np.random.seed(42)
         x = np.array(np.random.random_sample((1, 28, 28)), np.float32)
         y = model.pred(x)

--- a/model.py
+++ b/model.py
@@ -9,20 +9,55 @@ if platform == 'android':
     InterpreterOptions = autoclass('org.tensorflow.lite.Interpreter$Options')
     Tensor = autoclass('org.tensorflow.lite.Tensor')
     DataType = autoclass('org.tensorflow.lite.DataType')
-    TensorBuffer = autoclass(
-        'org.tensorflow.lite.support.tensorbuffer.TensorBuffer')
+    TensorBuffer = autoclass('org.tensorflow.lite.support.tensorbuffer.TensorBuffer')
     ByteBuffer = autoclass('java.nio.ByteBuffer')
+    GpuDelegate = autoclass('org.tensorflow.lite.gpu.GpuDelegate')
+    GpuDelegateOptions = autoclass('org.tensorflow.lite.gpu.GpuDelegate$Options')
+    CompatibilityList = autoclass('org.tensorflow.lite.gpu.CompatibilityList')
 
     # dummy import so buildozer isn't cutting it away since it's used by options.setNumThreads
     InterpreterApiOptions = autoclass('org.tensorflow.lite.InterpreterApi$Options')
+    Delegate = autoclass('org.tensorflow.lite.Delegate')
 
     class TensorFlowModel():
-        def load(self, model_filename, num_threads=None):
-            model = File(model_filename)
-            options = InterpreterOptions()
-            if num_threads is not None:
-                options.setNumThreads(num_threads)
-            self.interpreter = Interpreter(model, options)
+        """
+        Crossplatform inference for .tflite models
+        
+        :param model_filename: Path to the model
+        :type model_filename: str
+        :param num_threads: Number of threads to use
+        :type num_threads: int
+        :param use_gpu: Use GPU acceleration if available
+        :type use_gpu: bool
+        :param precision_loss: GPU only: Uses FP16 internally providing significant speed ups, might come with major quality degradation
+        :type precision_loss: bool
+        :param sustained_speed: GPU only: Load the model to achieve maximum speed (takes really long; only for small models worth it)
+        :type sustained_speed: bool
+        """
+        def __init__(self, model_filename: str, num_threads: int = 1, use_gpu: bool = True, precision_loss: bool = True, sustained_speed: bool = False):
+            self.model_filename = model_filename
+            self.options = InterpreterOptions()
+            self.compatList = CompatibilityList()
+            if use_gpu and self.compatList.isDelegateSupportedOnThisDevice():
+                delegate_options = self.compatList.getBestOptionsForThisDevice()
+                delegate_options = (
+                    delegate_options
+                    .setPrecisionLossAllowed(precision_loss)
+                    .setInferencePreference(1 if sustained_speed else 0)
+                )
+                gpu_delegate = GpuDelegate(delegate_options)
+                self.options.addDelegate(gpu_delegate)
+                print("set gpu")
+            else:
+                self.options.setNumThreads(num_threads)
+                self.options.setUseXNNPACK(True)
+
+        def load(self):
+            """
+            Loads the model from the path given in the constructor. This takes some time (for a CNN with 15M parameters around 2s)
+            """
+            model = File(self.model_filename)
+            self.interpreter = Interpreter(model, self.options)
             self.allocate_tensors()
 
         def allocate_tensors(self):
@@ -40,13 +75,16 @@ if platform == 'android':
                 self.allocate_tensors()
 
         def pred(self, x):
+            """
+            Run inference.
+            
+            :param x: Input numpy array
+            """
             # assumes one input and one output for now
             input = ByteBuffer.wrap(x.tobytes())
-            output = TensorBuffer.createFixedSize(self.output_shape,
-                                                  self.output_type)
+            output = TensorBuffer.createFixedSize(self.output_shape, self.output_type)
             self.interpreter.run(input, output.getBuffer().rewind())
-            return np.reshape(np.array(output.getFloatArray()),
-                              self.output_shape)
+            return np.reshape(np.array(output.getFloatArray()), self.output_shape)
 
 elif platform == 'ios':
     from pyobjus import autoclass, objc_arr # type: ignore
@@ -57,7 +95,7 @@ elif platform == 'ios':
     Interpreter = autoclass('TFLInterpreter')
     InterpreterOptions = autoclass('TFLInterpreterOptions')
     NSData = autoclass('NSData')
-    NSMutableArray = autoclass("NSMutableArray")
+    NSMutableArray = autoclass('NSMutableArray')
 
     class TensorFlowModel:
         def load(self, model_filename, num_threads=None):


### PR DESCRIPTION
Hi,
here's the PR introducing gpu acceleration (on android). This brings a nice speedup on most devices

My code is based off the example code which can be found [here](https://ai.google.dev/edge/litert/android/gpu?hl=en#enable_gpu_acceleration_2).

I changed the class layout because pyjnius has problems with loading java classes outside the main thread. 
Therefore the new structure would be:
1. create TensorFlowModel class inside the main thread (this creates the gpu delegate)
2. load the model inside a seperate thread (to be able to update ui)
3. run infernece inside a sperate thread

I pinned the android.gradle_dependencies to LiteRT v1.4.1 as google is currently working on LiteRT v2 which replaces the InterpreterAPI with the CompiledModelAPI (breaking code written for v1). If v2 is out of beta I'll make a PR again.